### PR TITLE
Fix RBAC: Use cluster-manager role

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,8 +18,7 @@ namePrefix: registries-operator
 # YAML string, with resources separated by document
 # markers ("---").
 resources:
-#- ../rbac/rbac_role.yaml
-#- ../rbac/rbac_role_binding.yaml
+- ./rbac/admin_role_binding.yaml
 - ../manager/manager.yaml
 
 #patches:

--- a/config/default/rbac/admin_role_binding.yaml
+++ b/config/default/rbac/admin_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: :controller-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: regs-controller
+  namespace: kube-system


### PR DESCRIPTION
## What does this PR change?

Use cluster-manager role instead of generated rbac while
proper role privilegies are defined.

## Documentation
- No documentation needed: **add explanation.**

- How to test the feature:  
 1. Deploy operator
 2. Create/update Registry
3, Check Registry's certificcate is copied to docker 

- [ ] **DONE**

## Test coverage
- No tests: onnly config files where modified

- [ ] **DONE**

## Links

(add here link to GitHub Issues)
Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**
