### PR TITLE
fix golint #21

### DIFF
--- a/cmd/registries-operator/main.go
+++ b/cmd/registries-operator/main.go
@@ -1,21 +1,19 @@
 /*
- * Copyright 2018 SUSE LINUX GmbH, Nuernberg, Germany..
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
+Copyright 2018 SUSE LINUX GmbH, Nuernberg, Germany..
 
-// Command main is a cli for this k8s operator
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 package main
 
 import (

--- a/cmd/registries-operator/main.go
+++ b/cmd/registries-operator/main.go
@@ -14,6 +14,8 @@
  * limitations under the License.
  *
  */
+
+// Command main is a cli for this k8s operator
 package main
 
 import (
@@ -39,8 +41,10 @@ import (
 	regcfg "github.com/kubic-project/registries-operator/pkg/config"
 )
 
-// to be set from the build process
+// Version is set from the build process
 var Version string
+
+// Build is set from the build process
 var Build string
 
 // newCmdManager runs the manager

--- a/pkg/apis/kubic/v1beta1/register.go
+++ b/pkg/apis/kubic/v1beta1/register.go
@@ -15,7 +15,6 @@
  *
  */
 
-
 //
 // NOTE: Boilerplate only.  Ignore this file.
 //

--- a/pkg/apis/kubic/v1beta1/registry_types.go
+++ b/pkg/apis/kubic/v1beta1/registry_types.go
@@ -46,7 +46,7 @@ type RegistryStatus struct {
 	Certificate RegistryCertificateStatus
 }
 
-// RegistryStatus defines the observed state of Registry
+// RegistryCertificateStatus defines the observed state of Registry
 type RegistryCertificateStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
@@ -73,7 +73,7 @@ type Registry struct {
 	Status RegistryStatus `json:"status,omitempty"`
 }
 
-// GetRegistryCert gets the certificate for a registry
+// GetCertificateSecret gets the certificate for a registry
 func (registry Registry) GetCertificateSecret(r client.Client) (*v1.Secret, error) {
 	if registry.Spec.Certificate == nil {
 		return nil, nil
@@ -88,8 +88,9 @@ func (registry Registry) GetCertificateSecret(r client.Client) (*v1.Secret, erro
 
 }
 
-func (r Registry) String() string {
-	return fmt.Sprintf("%s", r.Spec.HostPort)
+// String returns Registry HOST:PORT formatted address
+func (registry Registry) String() string {
+	return fmt.Sprintf("%s", registry.Spec.HostPort)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/kubic/v1beta1/registry_types.go
+++ b/pkg/apis/kubic/v1beta1/registry_types.go
@@ -88,7 +88,7 @@ func (registry Registry) GetCertificateSecret(r client.Client) (*v1.Secret, erro
 
 }
 
-// String returns Registry HOST:PORT formatted address
+// String returns registry HOST:PORT formatted address
 func (registry Registry) String() string {
 	return fmt.Sprintf("%s", registry.Spec.HostPort)
 }

--- a/pkg/config/globals.go
+++ b/pkg/config/globals.go
@@ -18,9 +18,9 @@
 package config
 
 var (
-	// A prefix for all the resources created by the operator
+	//DefaultPrefix for all the resources created by the operator
 	DefaultPrefix = "regsop"
 
-	// Default number of replicas for the Deployment
+	// DefaultDeployNumReplicas is the  number of replicas for the Deployment
 	DefaultDeployNumReplicas = 3
 )

--- a/pkg/config/globals.go
+++ b/pkg/config/globals.go
@@ -18,7 +18,7 @@
 package config
 
 var (
-	//DefaultPrefix for all the resources created by the operator
+	// DefaultPrefix for all the resources created by the operator
 	DefaultPrefix = "regsop"
 
 	// DefaultDeployNumReplicas is the  number of replicas for the Deployment

--- a/pkg/controller/registry/registry_cert_installer.go
+++ b/pkg/controller/registry/registry_cert_installer.go
@@ -76,7 +76,7 @@ func (r *ReconcileRegistry) reconcileCertPresent(registry *kubicv1beta1.Registry
 
 	// 3. Process all the Jobs that were launched from this controller
 	jobs, err := getAllJobsWithLabels(r, map[string]string{
-		jobInstallLabelHostPort: kubicutil.SafeId(registry.Spec.HostPort),
+		jobInstallLabelHostPort: kubicutil.SafeID(registry.Spec.HostPort),
 		jobInstallLabelHash:     specSecretHash,
 	})
 	if err != nil {
@@ -164,8 +164,8 @@ func (r *ReconcileRegistry) reconcileCertPresent(registry *kubicv1beta1.Registry
 func (r *ReconcileRegistry) installCertForRegistry(registry *kubicv1beta1.Registry, secret *corev1.Secret, numNodes int) error {
 	var err error
 
-	registryAddress := kubicutil.SafeId(registry.Spec.HostPort)
-	jobName := kubicutil.SafeId(jobInstallNamePrefix) + "-" + registryAddress
+	registryAddress := kubicutil.SafeID(registry.Spec.HostPort)
+	jobName := kubicutil.SafeID(jobInstallNamePrefix) + "-" + registryAddress
 
 	// note: docker cannot mount directories with colons (like "registry.suse.de:5000")
 	//       so we will use the path "/certs/this-registry/ca.crt"

--- a/pkg/controller/registry/registry_cert_remover.go
+++ b/pkg/controller/registry/registry_cert_remover.go
@@ -60,7 +60,7 @@ func (r *ReconcileRegistry) reconcileCertMissing(instance *kubicv1beta1.Registry
 	secretHash := instance.Status.Certificate.CurrentHash
 
 	jobs, err := getAllJobsWithLabels(r, map[string]string{
-		jobRemoveLabelHostPort: kubicutil.SafeId(instance.Spec.HostPort),
+		jobRemoveLabelHostPort: kubicutil.SafeID(instance.Spec.HostPort),
 		jobRemoveLabelHash:     secretHash,
 	})
 	if err != nil {
@@ -123,8 +123,8 @@ func (r *ReconcileRegistry) reconcileCertMissing(instance *kubicv1beta1.Registry
 func (r *ReconcileRegistry) removeCertForRegistry(registry *kubicv1beta1.Registry, secretHash string, numNodes int) error {
 	var err error
 
-	registryAddress := kubicutil.SafeId(registry.Spec.HostPort)
-	jobName := kubicutil.SafeId(jobRemoveNamePrefix) + "-" + registryAddress
+	registryAddress := kubicutil.SafeID(registry.Spec.HostPort)
+	jobName := kubicutil.SafeID(jobRemoveNamePrefix) + "-" + registryAddress
 
 	dstDir := filepath.Join(dockerCertsDir, registry.Spec.HostPort)
 

--- a/pkg/controller/registry/runner.go
+++ b/pkg/controller/registry/runner.go
@@ -126,7 +126,7 @@ func getRunnerJobWithSecrets(cfg *runnerWithSecrets) (*batchv1.Job, error) {
 	jobCont0.VolumeMounts = []corev1.VolumeMount{}
 
 	for hostPort, secret := range cfg.Secrets {
-		name := kubicutil.SafeId(hostPort)
+		name := kubicutil.SafeID(hostPort)
 
 		newVolume := corev1.Volume{
 			Name: name,

--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -15,7 +15,7 @@
  *
  */
 
-// Package test is defined skip the specific test if we are not use running in integration testing mode
+// Package test contains specific test utilities which can be used by operator
 package test
 
 import (

--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -14,6 +14,8 @@
  * limitations under the License.
  *
  */
+
+// Package test is defined skip the specific test if we are not use running in integration testing mode
 package test
 
 import (

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 )
 
-// SafeId returns a safe ID (for example, for using in YAML)
+// SafeID returns a safe ID (for example, for using in YAML)
 // ie, "Something:6000/ddd" becomes "something-6000-ddd"
-func SafeId(s string) string {
+func SafeID(s string) string {
 	replacer := strings.NewReplacer(" ", "-", ":", "-", "/", "-", ".", "-")
 	return replacer.Replace(strings.ToLower(s))
 }


### PR DESCRIPTION
## What does this PR change?

#21 

## Documentation
- No documentation needed: because it is not feature and only fix linting
- [x] **DONE**


## Test coverage
- test make check in localhost
```
$git pull --rebase fork issue-21
remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Total 16 (delta 9), reused 9 (delta 9), pack-reused 7
Unpacking objects: 100% (16/16), done.
From https://github.com/u5surf/registries-operator
 * branch            issue-21   -> FETCH_HEAD
 * [new branch]      issue-21   -> fork/issue-21
Updating 30a1301..e0094aa
Fast-forward
 cmd/registries-operator/main.go          | 6 +++++-
 pkg/apis/kubic/v1beta1/register.go       | 1 -
 pkg/apis/kubic/v1beta1/registry_types.go | 9 +++++----
 pkg/config/globals.go                    | 4 ++--
 pkg/test/util.go                         | 2 ++
 pkg/util/strings.go                      | 4 ++--
 6 files changed, 16 insertions(+), 10 deletions(-)
Current branch issue-21 is up to date.
$git log
commit e0094aaa69a91b0731dd3cffd4591c6bdd64cfc9 (HEAD -> issue-21, fork/issue-21)
commit e0094aaa69a91b0731dd3cffd4591c6bdd64cfc9 (HEAD -> issue-21, fork/issue-21
)
Author: u5surf <u5.horie@gmail.com>
Date:   Mon Nov 26 09:10:25 2018 +0900

    fix golint #21

commit 30a1301c0d8c22cf3c4cbf70af210362cc734fb2 (origin/master, origin/HEAD, master)
Merge: 534661b 9782e4e
Author: Rafael Fernández López <ereslibre@kde.org>
Date:   Fri Nov 23 16:59:58 2018 +0100

    Merge pull request #22 from kubic-project/fix-rbac

    Fix RBAC: Use cluster-manager role

commit 9782e4ec1612a5563ad5a60b13030d7288645163
Author: Pablo Chacin <pchacin@suse.com>
Date:   Fri Nov 23 16:23:01 2018 +0100

    Fix RBAC: Use cluster-manager role

    Use cluster-manager role instead of generated rbac while
$make check
>>> Reformatting code
go: finding github.com/golang/groupcache v0.0.0-20180924190550-6f2cf27854a4
go: finding github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf
go: finding github.com/spf13/cobra v0.0.3
go: finding github.com/spf13/pflag v1.0.3
go: finding github.com/inconshreveable/mousetrap v1.0.0
go: finding github.com/go-logr/logr v0.1.0
go: finding github.com/stevvooe/resumable v0.0.0-20180830230917-22b14a53ba50
go: finding github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c
go: finding golang.org/x/crypto v0.0.0-20180222182404-49796115aa4b
go: finding go.uber.org/atomic v1.3.2
go: finding k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d
go: finding github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742
go: finding k8s.io/utils v0.0.0-20180918230422-cd34563cd63c
go: finding go.uber.org/multierr v1.1.0
go: finding github.com/ghodss/yaml v1.0.0
go: finding github.com/ugorji/go v1.1.1
go: finding k8s.io/api v0.0.0-20180712090710-2d6f90ab1293
go: finding golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2
go: finding github.com/google/uuid v1.0.0
go: finding github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a
go: finding github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709
go: finding github.com/docker/distribution v2.6.2+incompatible
go: finding github.com/go-logr/zapr v0.1.0
go: finding k8s.io/kube-openapi v0.0.0-20180928202339-9dfdf9be683f
go: finding golang.org/x/sys v0.0.0-20181005133103-4497e2df6f9e
go: finding k8s.io/apiextensions-apiserver v0.0.0-20180808065829-408db4a50408
go: finding golang.org/x/net v0.0.0-20181005035420-146acd28ed58
go: finding github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
go: finding k8s.io/apiserver v0.0.0-20180808060109-1844acd6a035
go: finding go.uber.org/zap v1.9.1
go: finding github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: finding github.com/json-iterator/go v1.1.5
go: finding golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced
go: finding gopkg.in/inf.v0 v0.9.1
go: finding sigs.k8s.io/testing_frameworks v0.0.0-20180709092217-5818a3a284a1
go: finding github.com/peterbourgon/diskv v2.0.1+incompatible
go: finding sigs.k8s.io/controller-runtime v0.1.4
go: finding k8s.io/kubernetes v1.11.3
go: finding k8s.io/client-go v0.0.0-20180806134042-1f13a808da65
go: finding github.com/imdario/mergo v0.3.6
go: finding github.com/googleapis/gnostic v0.2.0
go: finding github.com/renstrom/dedent v1.0.0
go: downloading k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d
go: downloading k8s.io/api v0.0.0-20180712090710-2d6f90ab1293
go: downloading sigs.k8s.io/controller-runtime v0.1.4
go: downloading k8s.io/kubernetes v1.11.3
go: downloading k8s.io/client-go v0.0.0-20180806134042-1f13a808da65
go: downloading github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf
go: downloading k8s.io/apiserver v0.0.0-20180808060109-1844acd6a035
go: downloading github.com/spf13/pflag v1.0.3
go: downloading golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced
go: downloading github.com/golang/groupcache v0.0.0-20180924190550-6f2cf27854a4
go: downloading github.com/spf13/cobra v0.0.3
go: downloading github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
go: downloading github.com/ghodss/yaml v1.0.0
go: downloading github.com/renstrom/dedent v1.0.0
go: downloading golang.org/x/net v0.0.0-20181005035420-146acd28ed58
go: downloading github.com/go-logr/zapr v0.1.0
go: downloading k8s.io/kube-openapi v0.0.0-20180928202339-9dfdf9be683f
go: downloading go.uber.org/zap v1.9.1
go: downloading github.com/go-logr/logr v0.1.0
go: downloading github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
go: downloading cloud.google.com/go v0.30.0
go: downloading github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a
go: downloading github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709
go: downloading github.com/peterbourgon/diskv v2.0.1+incompatible
go: downloading golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2
go: downloading github.com/imdario/mergo v0.3.6
go: downloading github.com/json-iterator/go v1.1.5
go: downloading github.com/google/uuid v1.0.0
go: downloading github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c
go: downloading gopkg.in/inf.v0 v0.9.1
go: downloading go.uber.org/atomic v1.3.2
go: downloading github.com/googleapis/gnostic v0.2.0
go: downloading golang.org/x/crypto v0.0.0-20180222182404-49796115aa4b
go: downloading go.uber.org/multierr v1.1.0
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: downloading github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742
go: downloading golang.org/x/sys v0.0.0-20181005133103-4497e2df6f9e
go: downloading k8s.io/utils v0.0.0-20180918230422-cd34563cd63c
go: downloading github.com/ugorji/go v1.1.1
>>> Reformatting code
```
- [x] **DONE**

## Links
(add here link to GitHub Issues)
Fixes #21 

- [x] **DONE**
