### PR TITLE
Golint make it fails if there are syntax errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ golint:
 
 .PHONY: check
 check: fmt golint 
-	@for d in $$($(GO) list ./... | grep -v /vendor/); do golint $${d}; done
+	@for d in $$($(GO) list ./... | grep -v /vendor/); do golint -set_exit_status $${d}; done
 	@$(GO) tool vet ${REGS_OPER_SRCS}
 
 .PHONY: test


### PR DESCRIPTION
## What does this PR change?

Make golint fails in target `check` with specific option.
Previously we didn't fail.

## Links

Depends on #23 