### PR TITLE
Fix version subcommands and generated output

### DIFF
--- a/cmd/registries-operator/main.go
+++ b/cmd/registries-operator/main.go
@@ -100,7 +100,6 @@ func newCmdVersion(out io.Writer) *cobra.Command {
 			fmt.Fprintf(out, "registries-operator version: %s (build: %s)\n", Version, Build)
 		},
 	}
-	cmd.Flags().StringP("output", "o", "", "Output format; available options are 'yaml', 'json' and 'short'")
 	return cmd
 }
 


### PR DESCRIPTION
Fix version command and flag -o which shows
version output in following formats 'yaml', 'json'
and 'short'.
