### PR TITLE
Re-introduce config/crds dir

### DIFF
--- a/config/crds/kubic_v1beta1_registry.yaml
+++ b/config/crds/kubic_v1beta1_registry.yaml
@@ -1,0 +1,38 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: registries.kubic.opensuse.org
+spec:
+  group: kubic.opensuse.org
+  names:
+    kind: Registry
+    plural: registries
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            certificate:
+              type: object
+            hostPort:
+              type: string
+          type: object
+        status:
+          type: object
+  version: v1beta1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
Reintroduce the config/crds directory with the generated crd
definition to ensure the directory exists and make this file
available to integration tests without having to generate it
for each test.

## Documentation
- No documentation needed
- [ ] **DONE**

## Test coverage
- No tests:

- [ ] **DONE**

## Links

(add here link to GitHub Issues)
Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**
