### PR TITLE
Use a specific sa for spawned jobs that can potentially have different permissions than the manager.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Docker registries operator for Kubernetes, developed inside the
 
 * Automatic installation of registries certificates based on
 some [CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)s.
- 
+
 # Current status
 
 **Alpha**: we are still adding features and fixing many bugs...
@@ -29,11 +29,11 @@ Before we have a functional POC we need to implement:
     ```
     kubectl apply -f https://raw.githubusercontent.com/kubic-project/registries-operator/master/deployments/registries-operator-full.yaml
     ```
-    
+
 * once the operator is running, store the certificate for your registry in a _Secret_ with:
 
     ```
-    kubectl create secret generic suse-ca-crt --from-file=ca.crt=/etc/pki/trust/anchors/SUSE_CaaSP_CA.crt
+    kubectl create secret generic suse-ca-crt --from-file=ca.crt=/etc/pki/trust/anchors/SUSE_CaaSP_CA.crt -n kube-system
     ```
 
   where `/etc/pki/trust/anchors/SUSE_CaaSP_CA.crt` is the certificate and `suse-ca-crt` is the _Secret_.
@@ -53,8 +53,8 @@ Before we have a functional POC we need to implement:
       certificate:
         name: suse-ca-crt
         namespace: kube-system
-    ``` 
-    
+    ```
+
     then you can load it with `kubectl apply -f registry.yaml`.
 
 * once this is done, the `suse-ca-crt` should automatically appear in all

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -19,6 +19,7 @@ namePrefix: registries-operator
 # markers ("---").
 resources:
 - ./rbac/admin_role_binding.yaml
+- ./rbac/job_role_binding.yaml
 - ../manager/manager.yaml
 
 #patches:

--- a/config/default/rbac/job_role_binding.yaml
+++ b/config/default/rbac/job_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: :job-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: regs-jobs
+  namespace: kube-system

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - kubic.opensuse.org
+  resources:
+  - registries
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/rbac/rbac_role_binding.yaml
+++ b/config/rbac/rbac_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/sas/jobs-service-account.yaml
+++ b/config/sas/jobs-service-account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: regs-controller
+  name: regs-jobs
   namespace: kube-system

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -1,3 +1,3 @@
 # `registries controller`  deployments
 
-* [`Full deployment`](registries-operator-full.yam).
+* [`Full deployment`](registries-operator-full.yaml).

--- a/deployments/registries-operator-full.yaml
+++ b/deployments/registries-operator-full.yaml
@@ -9,7 +9,12 @@ kind: ServiceAccount
 metadata:
   name: regs-controller
   namespace: kube-system
-  
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: regs-jobs
+  namespace: kube-system
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -63,6 +68,20 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: regs-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: registries-operator:job-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: regs-jobs
   namespace: kube-system
 ---
 apiVersion: v1

--- a/pkg/config/globals.go
+++ b/pkg/config/globals.go
@@ -21,6 +21,9 @@ var (
 	// DefaultPrefix for all the resources created by the operator
 	DefaultPrefix = "regsop"
 
+	// JobServiceAccountName is the service account name for spawned jobs
+	JobServiceAccountName = "regs-jobs"
+
 	// DefaultDeployNumReplicas is the  number of replicas for the Deployment
 	DefaultDeployNumReplicas = 3
 )

--- a/pkg/controller/registry/runner.go
+++ b/pkg/controller/registry/runner.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kubic-project/registries-operator/pkg/config"
 	kubicutil "github.com/kubic-project/registries-operator/pkg/util"
 )
 
@@ -48,7 +49,8 @@ var (
 			//Completions: 0,  // to be set
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyNever,
+					RestartPolicy:      corev1.RestartPolicyNever,
+					ServiceAccountName: config.JobServiceAccountName,
 					Tolerations: []corev1.Toleration{
 						{
 							Key:      "node-role.kubernetes.io/master",


### PR DESCRIPTION
## What does this PR change?

Use a specific sa for spawned jobs that can potentially have different permissions than the manager.

Also:
* Fix the instructions on the README to create the example crt on the `kube-system` namespace as
  it's used on the next step.
* Fix a broken link on the README.