### PR TITLE
Refactor ReconcileRegistry for Testability

### DIFF
--- a/pkg/controller/registry/registry_cert_installer.go
+++ b/pkg/controller/registry/registry_cert_installer.go
@@ -49,7 +49,7 @@ const (
 )
 
 // reconcileCertPresent reconciles the Certificate for this Registry
-func (r *ReconcileRegistry) reconcileCertPresent(registry *kubicv1beta1.Registry,
+func (r *ReconcileRegistry) ReconcileCertPresent(registry *kubicv1beta1.Registry,
 	curNodes map[string]*corev1.Node,
 	specSecret *corev1.Secret) (reconcile.Result, error) {
 

--- a/pkg/controller/registry/registry_cert_remover.go
+++ b/pkg/controller/registry/registry_cert_remover.go
@@ -50,10 +50,11 @@ const (
 	regsFinalizerName = "registry.finalizers.kubic.opensuse.org"
 )
 
+
 // reconcileCertMissing removes all the things created by the controller for a Registry
 // Ensure that delete implementation is idempotent and safe to invoke
 // multiple types for same object.
-func (r *ReconcileRegistry) reconcileCertMissing(instance *kubicv1beta1.Registry, nodes map[string]*corev1.Node) error {
+func (r *ReconcileRegistry) ReconcileCertMissing(instance *kubicv1beta1.Registry, nodes map[string]*corev1.Node) error {
 
 	mustRemove := false
 

--- a/pkg/controller/registry/registry_controller_reconcilier_test.go
+++ b/pkg/controller/registry/registry_controller_reconcilier_test.go
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2018 SUSE LINUX GmbH, Nuernberg, Germany..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package registry
+
+import (
+	kubicv1beta1 "github.com/kubic-project/registries-operator/pkg/apis/kubic/v1beta1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"github.com/kubic-project/registries-operator/pkg/test"
+	"github.com/kubic-project/registries-operator/pkg/test/fake"
+	"k8s.io/apimachinery/pkg/types"
+	"golang.org/x/net/context"
+	. "github.com/onsi/gomega"
+	"testing"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+
+type FakeCertReconciler struct {
+	reconcileMissing bool
+	reconcilePresent bool
+}
+
+func NewFakeCertReconciler() *FakeCertReconciler {
+	return &FakeCertReconciler{false, false}
+}
+
+func newTestReconcileRegistry()  ReconcileRegistry {
+	return ReconcileRegistry{
+		fake.NewTestClient(),
+		fake.NewTestRecorder(),
+		scheme.Scheme,
+		NewFakeCertReconciler(),
+	}
+}
+
+func (r *FakeCertReconciler) ReconcileCertPresent(registry *kubicv1beta1.Registry,
+	curNodes map[string]*corev1.Node,
+	specSecret *corev1.Secret) (reconcile.Result, error) {
+
+	r.reconcilePresent = true;
+	return  reconcile.Result{}, nil
+}
+
+
+func	(r *FakeCertReconciler) ReconcileCertMissing(instance *kubicv1beta1.Registry, nodes map[string]*corev1.Node) error {
+	r.reconcileMissing = true;
+	return  nil
+
+}
+
+func TestReconcileRegistryNotFound(t *testing.T) {
+
+	g := NewGomegaWithT(t)
+
+	r := newTestReconcileRegistry()
+
+	req := reconcile.Request{types.NamespacedName{Name: "TestRegistry",Namespace: ""}}
+	res, _ := r.Reconcile(req)
+
+        g.Expect(res).To(Equal(reconcile.Result{}))
+	//neither of reconcile methods should be called
+	cr, _ :=r.certReconciler.(*FakeCertReconciler)
+	g.Expect(cr.reconcileMissing || cr.reconcilePresent).Should(Equal(false))
+
+}
+
+func TestReconcileRegistryFound(t *testing.T) {
+
+	g := NewGomegaWithT(t)
+
+	r := newTestReconcileRegistry()
+
+	fooSec, err := test.BuildSecretFromCert("foo-ca-crt", "foo.crt")
+
+	if err != nil {
+		t.Errorf("Error creating secret %v", err)
+	}
+
+	fooReg, err :=kubicv1beta1.GetTestRegistry("foo")
+	if err != nil {
+		t.Errorf("Error Getting Registry %v", err)
+	}
+
+	c := r.Client
+	c.Create(context.TODO(), fooSec)
+	c.Create(context.TODO(),fooReg)
+
+	req := reconcile.Request{types.NamespacedName{Name: fooReg.Name,Namespace: fooReg.Namespace}}
+	res, _ := r.Reconcile(req)
+
+        g.Expect(res).To(Equal(reconcile.Result{}))
+	//neither of reconcile methods should be called
+	cr, _ :=r.certReconciler.(*FakeCertReconciler)
+	g.Expect(cr.reconcilePresent).Should(Equal(true))
+
+}
+
+func TestReconcileRegistryCertRemoved(t *testing.T) {
+
+	g := NewGomegaWithT(t)
+
+	r := newTestReconcileRegistry()
+
+	fooReg, err :=kubicv1beta1.GetTestRegistry("foo")
+	if err != nil {
+		t.Errorf("Error Getting Registry %v", err)
+	}
+
+	fooSec, err := test.BuildSecretFromCert("foo-ca-crt", "foo.crt")
+	if err != nil {
+		t.Errorf("Error creating secret %v", err)
+	}
+	//simulate certificate was installed and then removed from Registry
+	fooReg.Status.Certificate.CurrentHash = getSecretHash(fooSec)
+	fooReg.Spec.Certificate = nil
+
+	c := r.Client
+	c.Create(context.TODO(),fooReg)
+
+	req := reconcile.Request{types.NamespacedName{Name: fooReg.Name,Namespace: fooReg.Namespace}}
+	res, _ := r.Reconcile(req)
+
+        g.Expect(res).To(Equal(reconcile.Result{}))
+	//neither of reconcile methods should be called
+	cr, _ :=r.certReconciler.(*FakeCertReconciler)
+	g.Expect(cr.reconcileMissing).Should(Equal(true))
+
+}
+
+func TestReconcileRegistryWithoutCert(t *testing.T) {
+
+	g := NewGomegaWithT(t)
+
+	r := newTestReconcileRegistry()
+
+	fooReg, err :=kubicv1beta1.GetTestRegistry("foo")
+	if err != nil {
+		t.Errorf("Error Getting Registry %v", err)
+	}
+
+	fooReg.Spec.Certificate = nil
+
+	c := r.Client
+	c.Create(context.TODO(),fooReg)
+
+	req := reconcile.Request{types.NamespacedName{Name: fooReg.Name,Namespace: fooReg.Namespace}}
+	res, _ := r.Reconcile(req)
+
+        g.Expect(res).To(Equal(reconcile.Result{}))
+	//neither of reconcile methods should be called
+	cr, _ :=r.certReconciler.(*FakeCertReconciler)
+	g.Expect(cr.reconcileMissing).Should(Equal(false))
+
+}

--- a/pkg/test/fake/client.go
+++ b/pkg/test/fake/client.go
@@ -15,7 +15,7 @@
  *
  */
 
-package fake 
+package fake
 
 import (
 	"context"
@@ -38,6 +38,7 @@ import (
  *
  * TODO: Remove this wrapper once the project is upgrded to a runtime v0.1.8 or up
  */
+
 type testClient struct {
 	fake   client.Client
 	scheme *runtime.Scheme

--- a/pkg/test/fake/recorder.go
+++ b/pkg/test/fake/recorder.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 SUSE LINUX GmbH, Nuernberg, Germany..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package fake 
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type FakeEvent struct {
+	Object runtime.Object
+	EventType string
+	Reason string
+	Message string
+	Annotations map[string]string
+}
+
+
+type FakeRecorder struct {
+	Events []FakeEvent
+}
+
+
+func NewTestRecorder() FakeRecorder {
+	return FakeRecorder{Events: []FakeEvent{}}
+}
+
+func (e FakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	e.Events = append(e.Events, FakeEvent{object, eventtype, reason, message, map[string]string{}})
+}
+
+// Eventf is just like Event, but with Sprintf for the message field.
+func (e FakeRecorder)Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}){
+}
+
+// PastEventf is just like Eventf, but with an option to specify the event's 'timestamp' field.
+func (e FakeRecorder)PastEventf(object runtime.Object, timestamp metav1.Time, eventtype, reason, messageFmt string, args ...interface{}){
+}
+
+    // AnnotatedEventf is just like eventf, but with annotations attached
+func (e FakeRecorder)AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}){
+}
+
+

--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -50,7 +50,7 @@ func BuildSecretFromCert(name string, certName string) (*corev1.Secret, error) {
 	}
 
 	secret := &corev1.Secret{
-		Type: corev1.SecretTypeOpaque, ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}, Data: map[string][]byte{"ca-cert": cert}}
+		Type: corev1.SecretTypeOpaque, ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}, Data: map[string][]byte{"ca.crt": cert}}
 
 	return secret, nil
 }


### PR DESCRIPTION
## What does this PR change?

Refactor the ReconcileRegistry logic to facilitat unit testing
separating the Reconcile Request processing from the actual
certificate install/remove logic.

Signed-off-by: Pablo Chacin <pchacin@suse.com>

## Documentation
- No documentation needed: only test are changed

- [ ] **DONE**

## Test coverage
- Unit tests were added
- [ ] **DONE**
